### PR TITLE
Fix ClassNotFound when VaultAdditions Mod is not present

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -169,7 +169,7 @@ dependencies {
     // implementation fg.deobf("com.tterrag.registrate:Registrate:MC${mc_version}-${registrate_version}") // Adds registrate as a dependency
 
     compileOnly fg.deobf("curse.maven:vault-additions-1166562:6326116")
-    runtimeOnly fg.deobf("curse.maven:vault-additions-1166562:6326116")
+//    runtimeOnly fg.deobf("curse.maven:vault-additions-1166562:6326116")
 
     //implementation fg.deobf("vazkii:autoreglib:AutoRegLib:${arl_version}")
     //implementation fg.deobf("vazkii:quark:Quark:${quark_version}")
@@ -226,6 +226,7 @@ tasks.named('processResources', ProcessResources).configure {
             loader_version_range: loader_version_range,
             mod_id: mod_id, mod_name: mod_name, mod_license: mod_license, mod_version: mod_version,
             mod_authors: mod_authors, mod_description: mod_description,
+            vault_additions_version_range: vault_additions_version_range,
     ]
 
     inputs.properties replaceProperties

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ mod_name=JustEnoughVH
 mod_license=GNU GPLv3
 mod_version=1.0
 mod_group_id=dev.attackeight
-mod_authors=attackeight
+mod_authors=attackeight, PINPAL
 mod_description=Adds JEI Compatibility for Vault Hunters
 
 gekolib_version = 3.0.57
@@ -21,3 +21,4 @@ jei_version = 9.7.2.281
 curios_version = 5.0.9.0
 arl_version = 1.7-53.110
 quark_version = 3.2-358.1
+vault_additions_version_range = [1.15.0,)

--- a/src/main/java/dev/attackeight/just_enough_vh/jei/TheVaultJEIPlugin.java
+++ b/src/main/java/dev/attackeight/just_enough_vh/jei/TheVaultJEIPlugin.java
@@ -5,7 +5,6 @@ import dev.attackeight.just_enough_vh.jei.category.*;
 import static dev.attackeight.just_enough_vh.jei.JEIRecipeProvider.*;
 
 import dev.attackeight.just_enough_vh.utils.ModConfig;
-import io.github.a1qs.vaultadditions.config.CustomVaultConfigRegistry;
 import iskallia.vault.init.ModBlocks;
 import iskallia.vault.init.ModConfigs;
 import iskallia.vault.init.ModItems;
@@ -136,10 +135,8 @@ public class TheVaultJEIPlugin implements IModPlugin {
             registration.addRecipes(PANDORAS_BOX, getFromPool(ModConfigs.PANDORAS_BOX.POOL));
         }
         if (JustEnoughVH.vaLoaded()) {
-            registration.addRecipes(VA_ARENA_STATUE, getStatueLoot(CustomVaultConfigRegistry.STATUE_LOOT_ARENA));
-            registration.addRecipes(VA_GIFT_STATUE, getStatueLoot(CustomVaultConfigRegistry.STATUE_LOOT_GIFT));
-            registration.addRecipes(VA_MEGA_GIFT_STATUE, getStatueLoot(CustomVaultConfigRegistry.STATUE_LOOT_MEGA_GIFT));
-            registration.addRecipes(VA_VAULT_STATUE, getStatueLoot(CustomVaultConfigRegistry.STATUE_LOOT_VAULT));
+            // Register Vault Additions recipes in a separate class to avoid ClassNotFoundException
+            VaultAdditionsJEIPlugin.registerStatueRecipes(registration);
         }
     }
 

--- a/src/main/java/dev/attackeight/just_enough_vh/jei/VaultAdditionsJEIPlugin.java
+++ b/src/main/java/dev/attackeight/just_enough_vh/jei/VaultAdditionsJEIPlugin.java
@@ -1,0 +1,17 @@
+package dev.attackeight.just_enough_vh.jei;
+
+import io.github.a1qs.vaultadditions.config.CustomVaultConfigRegistry;
+import mezz.jei.api.registration.IRecipeRegistration;
+
+import static dev.attackeight.just_enough_vh.jei.JEIRecipeProvider.getStatueLoot;
+import static dev.attackeight.just_enough_vh.jei.TheVaultJEIPlugin.*;
+
+public class VaultAdditionsJEIPlugin {
+
+	public static void registerStatueRecipes(IRecipeRegistration registration) {
+		registration.addRecipes(VA_ARENA_STATUE, getStatueLoot(CustomVaultConfigRegistry.STATUE_LOOT_ARENA));
+		registration.addRecipes(VA_GIFT_STATUE, getStatueLoot(CustomVaultConfigRegistry.STATUE_LOOT_GIFT));
+		registration.addRecipes(VA_MEGA_GIFT_STATUE, getStatueLoot(CustomVaultConfigRegistry.STATUE_LOOT_MEGA_GIFT));
+		registration.addRecipes(VA_VAULT_STATUE, getStatueLoot(CustomVaultConfigRegistry.STATUE_LOOT_VAULT));
+	}
+}

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -26,3 +26,10 @@ description='''${mod_description}'''
    versionRange="${minecraft_version_range}"
    ordering="NONE"
    side="BOTH"
+[[dependencies."${mod_id}"]]
+   modId="vaultadditions"
+   # Optional dependency, Vault Additions has integration but is not required
+   mandatory=false
+   versionRange="${vault_additions_version_range}"
+   ordering="NONE"
+   side="BOTH"


### PR DESCRIPTION
### Changes:
- Implements a fix for #6
  - Move all imports for Vault Additions classes to [VaultAdditionsJEIPlugin Class](https://github.com/PINPAL/VaultHuntersJEIIntegration/blob/master/src/main/java/dev/attackeight/just_enough_vh/jei/VaultAdditionsJEIPlugin.java) that gets loaded conditionally depending on if the Vault Additions mod itself is loaded preventing any exceptions from occurring.
  - Add an *optional* dependency to [mods.toml](https://github.com/PINPAL/VaultHuntersJEIIntegration/blob/82e7aacb4f71334510d06462b7995b24e124c4ce/src/main/resources/META-INF/mods.toml#L29) for the Vault Additions mod